### PR TITLE
remove numpy array comparison with None warnings

### DIFF
--- a/circuitscape/cfg.py
+++ b/circuitscape/cfg.py
@@ -96,7 +96,7 @@ class CSConfig:
             o.update(olist)
         self.options = o
         
-        if None == cfgfile:
+        if cfgfile is None:
             return
         
         if not os.path.isfile(cfgfile):
@@ -123,9 +123,9 @@ class CSConfig:
             for option in CSConfig.DEFAULTS[section].keys():
                 val = self.options[option]
                 if option in CSConfig.FILE_PATH_PROPS:
-                    if (val == None) or (val == CSConfig.DEFAULTS[section][option]):
+                    if (val is None) or (val == CSConfig.DEFAULTS[section][option]):
                         val = ''
-                    elif (not os.path.isabs(val)) and (rel_to_abs != None):
+                    elif (not os.path.isabs(val)) and (rel_to_abs is not None):
                         val = os.path.join(rel_to_abs, val)
                 result[option] = val
         return result
@@ -136,7 +136,7 @@ class CSConfig:
             defaults.update(olist)
             
         for name in CSConfig.FILE_PATH_PROPS:
-            if not ((name in self.options) and (self.options[name] != defaults[name]) and (self.options[name] != None)):
+            if not ((name in self.options) and (self.options[name] != defaults[name]) and (self.options[name] is not None)):
                 continue
             
             if os.path.isabs(self.options[name]):

--- a/circuitscape/compute.py
+++ b/circuitscape/compute.py
@@ -453,7 +453,7 @@ class Compute(ComputeBase):
 
     def _post_pairwise_polygon_solve(self, resistances, pt1_idx, pt2_idx, solver_failed, msg):
         def _post_callback(pairwise_resistance):
-            if None != pairwise_resistance:
+            if pairwise_resistance is not None:
                 resistances[pt2_idx, pt1_idx] = resistances[pt1_idx, pt2_idx] = pairwise_resistance[0,1]
                 Compute.logger.info("Solved focal pair " + msg)
             else:
@@ -527,7 +527,7 @@ class Compute(ComputeBase):
                         self.state.worker_pool_wait()                        
                     self.state.del_amg_hierarchy()
                     
-                    if (local_dst != None) and (G_dst_dst != None):
+                    if (local_dst is not None) and (G_dst_dst is not None):
                         G[local_dst, local_dst] = G_dst_dst
                         local_dst = G_dst_dst = None
                     
@@ -548,12 +548,12 @@ class Compute(ComputeBase):
                     Compute.logger.info('Solving ' + msg)
                 
                 local_src = fp.get_graph_node_idx(pt2_idx, local_node_map)
-                if None == local_dst:
+                if local_dst is None:
                     local_dst = fp.get_graph_node_idx(pt1_idx, local_node_map)
                     G_dst_dst = G[local_dst, local_dst]
                     G[local_dst, local_dst] = 0
 
-                if self.state.amg_hierarchy == None:
+                if self.state.amg_hierarchy is None:
                     self.state.create_amg_hierarchy(G, self.options.solver)
 
                 if use_resistance_calc_shortcut:
@@ -595,10 +595,10 @@ class Compute(ComputeBase):
         def _post_callback(voltages):
             options = self.options
             
-            if msg != None:
+            if msg is not None:
                 self.logger.debug("solved " + msg)
             
-            if voltages == None:
+            if voltages is None:
                 solver_failed_somewhere[0] = True
                 resistances[pt2_idx, pt1_idx] = resistances[pt1_idx, pt2_idx] = -777
                 if use_resistance_calc_shortcut:
@@ -652,22 +652,22 @@ class Compute(ComputeBase):
         solver_called = False
         solver_failed = False
         node_map = None 
-        if component_with_points != None:
+        if component_with_points is not None:
             G = g_habitat.get_graph()
             G = ComputeBase.laplacian(G)
             node_map = g_habitat.node_map
         
-        vc_map_id = '' if source_id==None else str(source_id)
+        vc_map_id = '' if (source_id is None) else str(source_id)
         out.alloc_v_map(vc_map_id)
         
         if self.options.write_cur_maps:
             out.alloc_c_map(vc_map_id)
             
         for comp in range(1, g_habitat.num_components+1):
-            if (component_with_points != None) and (comp != component_with_points):
+            if (component_with_points is not None) and (comp != component_with_points):
                 continue
 
-            if component_with_points == None:
+            if component_with_points is None:
                 (G, node_map) = g_habitat.prune_nodes_for_component(comp)
                 G = ComputeBase.laplacian(G)
 
@@ -692,7 +692,7 @@ class Compute(ComputeBase):
                 else:
                     grounds = np.where(grounds == -9999, 0, grounds)
                     
-                if component_with_points == None:
+                if component_with_points is None:
                     sources = g_habitat.prune_for_component(comp, sources)
                     grounds = g_habitat.prune_for_component(comp, grounds)
                                                             
@@ -753,7 +753,7 @@ class Compute(ComputeBase):
         if solver_failed==False and self.options.write_volt_maps:
             out.write_v_map(vc_map_id)
             
-        if (self.options.write_cur_maps) and ((source_id == None) or ((source_id != None) and (self.options.write_cum_cur_map_only==False))):
+        if (self.options.write_cur_maps) and ((source_id is None) or ((source_id is not None) and (self.options.write_cum_cur_map_only==False))):
             out.write_c_map(vc_map_id, node_map=g_habitat.node_map)
             
         if self.options.scenario=='one-to-all':

--- a/circuitscape/compute_base.py
+++ b/circuitscape/compute_base.py
@@ -50,7 +50,7 @@ class ComputeBase(object):
         logger = logging.getLogger(logger_name)
         logger.setLevel(log_lvl)
         
-        if formatter == None:
+        if formatter is None:
             formatter = ComputeBase._create_formatter(log_lvl)
 
         handlers = []
@@ -83,7 +83,7 @@ class ComputeBase(object):
             handler.close()
             
     def _setup_loggers(self, ext_log_handler):
-        if None != ComputeBase.logger:  # logger has already been setup
+        if ComputeBase.logger is not None:  # logger has already been setup
             ComputeBase._close_handlers(ComputeBase.logger)
             ComputeBase._close_handlers(ResourceLogger.rlogger)
         
@@ -308,7 +308,7 @@ class FocalPoints:
 
     def _prune_included_pairs(self):
         """Remove excluded points from focal node list when using extra file that lists pairs to include/exclude."""
-        if self.incl_pairs == None:
+        if self.incl_pairs is None:
             return
 
         idx = 0
@@ -364,7 +364,7 @@ class FocalPoints:
         if self.is_network:
             raise RuntimeError('Not available in network mode')
           
-        if pt_idx != None:
+        if pt_idx is not None:
             return (self.points_rc[pt_idx,1], self.points_rc[pt_idx,2])
             
         return self.points_rc
@@ -451,7 +451,7 @@ class FocalPoints:
             
             for pt1_idx in range(0, numpoints): 
                 for pt2_idx in range(pt1_idx+1, numpoints):
-                    if (None != self.incl_pairs) and not self.incl_pairs.is_included_pair(self.point_ids[pt1_idx], self.point_ids[pt2_idx]):
+                    if (self.incl_pairs is not None) and not self.incl_pairs.is_included_pair(self.point_ids[pt1_idx], self.point_ids[pt2_idx]):
                         continue
                     yield (pt1_idx, pt2_idx)
                 yield(pt1_idx, -1)
@@ -486,7 +486,7 @@ class FocalPoints:
                 dst = self.get_graph_node_idx(pt1_idx, node_map)
                 if (dst <  0 or components[dst] != comp):
                     continue
-                if (None != self.incl_pairs):
+                if (self.incl_pairs is not None):
                     ccv = self.points_rc[:, 0]
                     inc = np.array([])
                     for pt in self.incl_pairs.get_possible_pair(self.points_rc[pt1_idx, 0]):
@@ -507,7 +507,7 @@ class FocalPoints:
 
 class HabitatGraph:
     def __init__(self, g_map=None, poly_map=None, connect_using_avg_resistances=False, connect_four_neighbors_only=False, g_graph=None, node_names=None):
-        if None != g_map:
+        if g_map is not None:
             self.is_network = False
             self.g_map = g_map
             self.poly_map = poly_map
@@ -770,7 +770,7 @@ class Output:
         self.state = state
         self.report_status = report_status
         self.node_names = node_names
-        self.nn_sorted = node_names[np.argsort(node_names)] if (None != node_names) else None
+        self.nn_sorted = node_names[np.argsort(node_names)] if (node_names is not None) else None
         
         self.is_network = (self.options.data_type == 'network')
         self.scenario = self.options.scenario
@@ -827,7 +827,7 @@ class Output:
         
     def _write_store_c_map(self, name, remove, write, accumulate, voltages, G, node_map, finitegrounds, local_src, local_dst):
         if self.is_network:
-            if voltages != None:
+            if voltages is not None:
                 (node_currents, branch_currents) = self._create_current_maps(voltages, G, finitegrounds)
                 branch_currents_array = Output._convert_graph_to_3_col(branch_currents, node_map)
             else:
@@ -852,7 +852,7 @@ class Output:
             else:
                 self.current_maps[name] = (branch_currents, node_currents, branch_currents_array, node_map)
         else:
-            if voltages != None:
+            if voltages is not None:
                 while LowMemRetry.retry():
                     with LowMemRetry():
                         current_map = self._create_current_maps(voltages, G, finitegrounds, node_map)   
@@ -917,7 +917,7 @@ class Output:
             ComputeBase.logger.info('writing voltage map ' + name)
             
         if self.is_network:
-            if voltages == None:
+            if voltages is None:
                 vm = self.voltage_maps[name]
                 nn = self.node_names
             else:
@@ -926,7 +926,7 @@ class Output:
             CSIO.write_voltages(self.options.output_file, vm, nn, name)
         else:
             fileadd = name if (name=='') else ('_'+name)
-            if voltages == None:
+            if voltages is None:
                 vm = self.voltage_maps[name]
             else:
                 vm = self._create_voltage_map(node_map, voltages)
@@ -934,7 +934,7 @@ class Output:
             
         if remove:
             self.rm_v_map(name)
-        elif voltages != None:
+        elif voltages is not None:
             if self.is_network:
                 self.alloc_v_map(name)
                 self.accumulate_v_map(name, voltages, node_map)
@@ -1064,7 +1064,7 @@ class Output:
         
         graph_n_col = np.zeros((Gcoo.row[mask].size, 3), dtype="float64") #Fixme: this may result in zero-current nodes being left out.  Needed to make change so dimensions would match Gcoo.data[mask]
         
-        if node_names == None:
+        if node_names is None:
             graph_n_col[:,0] = Gcoo.row[mask]
             graph_n_col[:,1] = Gcoo.col[mask]
         else:

--- a/circuitscape/gui.py
+++ b/circuitscape/gui.py
@@ -160,7 +160,7 @@ class GUI(model.Background):
             testsPassed = False
         finally:
             os.chdir(cwd)
-            if None != outdir:
+            if outdir is not None:
                 for root, dirs, files in os.walk(outdir, topdown=False):
                     for name in files:
                         os.remove(os.path.join(root, name))
@@ -216,7 +216,7 @@ class GUI(model.Background):
         self.components.calcButton.SetFocus()
         
         options_file_name = self.save_file_dlg('Choose a file name', '*.ini')
-        if options_file_name != None:                
+        if options_file_name is not None:                
             try:
                 self.options.write(options_file_name, True)
             except RuntimeError as ex:
@@ -374,7 +374,7 @@ class GUI(model.Background):
     def on_outBrowse_mouseClick(self, event):
         wildcard = "OUT Files (*.out)|*.out|All Files (*.*)|*.*"
         file_name = self.save_file_dlg('Choose a Base Output File Name', wildcard)
-        if file_name != None:
+        if file_name is not None:
             self.components.outFile.text = file_name
             self.options.output_file = file_name
 
@@ -421,7 +421,7 @@ class GUI(model.Background):
         
         out_base, _out_ext = os.path.splitext(self.options.output_file)
 
-        #if (self.options.log_file == None) or (not os.path.exists(self.options.log_file)): 
+        #if (self.options.log_file is None) or (not os.path.exists(self.options.log_file)): 
         self.options.log_file = out_base + '.log' # For now, just write log file to output directory.
 
         if (self.options.print_rusages and not sys.platform.startswith('win')) or (self.options.print_timings): 
@@ -721,10 +721,10 @@ class GUI(model.Background):
        
         idx = GUI.OPTIONS_LOG_LEVEL.index(self.options.log_level)
         self.components.logLevelChoice.SetSelection(idx)
-        if GUI.logger != None:
+        if GUI.logger is not None:
             GUI.logger.setLevel(getattr(logging, self.options.log_level.upper()))
 
-        if GUI.log_handler != None:
+        if GUI.log_handler is not None:
             GUI.log_handler.setLevel(getattr(logging, self.options.log_level.upper()))
 
         self.components.parallelSpin.value = self.components.parallelSpin.max = 1
@@ -804,7 +804,7 @@ class GUI(model.Background):
 
     def onLogEvent(self, event):
         self.components.logMessages.appendText(event.message + '\n')
-        if event.status_msg != None:
+        if event.status_msg is not None:
             self.statusBar.SetStatusText(event.status_msg[0], event.status_msg[1])
             if event.status_msg[1] == 1:
                 self.statusBar.SetStatusText('', 2)

--- a/circuitscape/gui_options.py
+++ b/circuitscape/gui_options.py
@@ -48,11 +48,11 @@ class OptionsWindow(model.CustomDialog):
         self.components.includePairsBox.checked     = self.childOptions.use_included_pairs and pairwise_enabled and is_pairwise_scenario
 
         self.components.polygonFile.text            = str(self.childOptions.polygon_file)
-        if self.childOptions.included_pairs_file != None:
+        if self.childOptions.included_pairs_file is not None:
             self.components.includePairsFile.text   = str(self.childOptions.included_pairs_file)
-        if self.childOptions.mask_file != None:
+        if self.childOptions.mask_file is not None:
             self.components.maskFile.text           = str(self.childOptions.mask_file) 
-        if self.childOptions.variable_source_file != None:
+        if self.childOptions.variable_source_file is not None:
             self.components.varSrcFile.text         = str(self.childOptions.variable_source_file)
 
         self.enable_disable_child_widgets(pairwise_enabled, advanced_enabled)

--- a/circuitscape/io.py
+++ b/circuitscape/io.py
@@ -295,7 +295,7 @@ class CSIO:
         (ncols, nrows, xllcorner, yllcorner, cellsize, nodata, _filetype) = header = CSIO._ascii_grid_read_header(filename)
         
         poly_map = CSIO._ascii_grid_reader(filename, data_type)
-        if nodata_as != None:
+        if nodata_as is not None:
             poly_map = np.where(poly_map==nodata, nodata_as, poly_map)
     
         if cellsize != habitat_size.cellsize:
@@ -511,7 +511,7 @@ class CSIO:
         cell_map = CSIO._ascii_grid_reader(habitat_map, 'float64')
     
         # Reclassification code
-        if reclass_file != None:
+        if reclass_file is not None:
             try:
                 reclass_table = CSIO.read_point_strengths(reclass_file)
             except:
@@ -546,7 +546,7 @@ class CSIO:
         out_file = out_base + '_resistances' + ('_incomplete' if incomplete else '') + out_extn
         np.savetxt(out_file, resistances, fmt='%.10g')
         
-        if resistances_3columns != None:
+        if resistances_3columns is not None:
             CSIO.write_resistances_3columns(outfile_template, resistances_3columns)
         
         #remove partial result file 
@@ -570,7 +570,7 @@ class CSIO:
             fileadd = ('_' + fileadd)
         elif options.scenario != 'advanced':
             fileadd = '_cum' #For backward compatibility
-        if branch_currents != None:
+        if branch_currents is not None:
             filename = out_base + '_branch_currents' + fileadd + '.txt'
             np.savetxt(filename, branch_currents, fmt='%.10g')
         filename = out_base + '_node_currents' + fileadd + '.txt'
@@ -581,7 +581,7 @@ class CSIO:
     def write_voltages(outfile_template, voltages, node_names, fileadd):
         """Saves voltage values from solving arbitrary graphs to disk."""
         output_voltages = np.zeros((len(voltages),2), dtype='float64')
-        if node_names != None:
+        if node_names is not None:
             output_voltages[:,0] = node_names[:]
         output_voltages[:,1] = voltages[:]
 

--- a/circuitscape/profiler.py
+++ b/circuitscape/profiler.py
@@ -229,7 +229,7 @@ class LowMemRetry:
         if isinstance(value, MemoryError):
             LowMemRetry.is_memory_error = True
             LowMemRetry.retry_count += 1
-            if (None != LowMemRetry.callback):
+            if (LowMemRetry.callback is not None):
                 LowMemRetry.callback(etype, value, traceback)
 
             if LowMemRetry.retry():

--- a/circuitscape/state.py
+++ b/circuitscape/state.py
@@ -28,7 +28,7 @@ class CSState:
         self.yllcorner = None
 
     def worker_pool_create(self, max_workers, reuse=False):
-        if(None != self.worker_pool):
+        if(self.worker_pool is not None):
             if reuse:
                 return
             else:
@@ -39,7 +39,7 @@ class CSState:
 
 
     def worker_pool_submit(self, function, callback, *args):
-        if(None != self.worker_pool):
+        if(self.worker_pool is not None):
             self.worker_pool.apply_async(self.async(function), args=args, callback=callback)
         else:
             try:
@@ -52,7 +52,7 @@ class CSState:
             
 
     def worker_pool_wait(self):
-        if self.worker_pool != None:
+        if self.worker_pool is not None:
             self.worker_pool.close()
             self.worker_pool.join()
             self.worker_pool = None
@@ -60,7 +60,7 @@ class CSState:
         
     @gc_after
     def del_amg_hierarchy(self):
-        if self.amg_hierarchy != None:
+        if self.amg_hierarchy is not None:
             self.amg_hierarchy = None
 
     @print_rusage

--- a/circuitscape/verify/verify_routines.py
+++ b/circuitscape/verify/verify_routines.py
@@ -48,7 +48,7 @@ def set_paths(root_path=None, out_path=None):
     
     TESTS_CFG       = os.path.join(TESTS_ROOT,  'verify', 'config_files')
     TESTS_BASELINE  = os.path.join(TESTS_ROOT,  'verify', 'baseline_results')
-    if None == TESTS_OUT:
+    if TESTS_OUT is None:
         TESTS_OUT   = os.path.join(TESTS_ROOT,  'verify', 'output')
 
 def cs_verifyall(root_path=None, out_path=None, ext_logger=None, stream=None):
@@ -56,7 +56,7 @@ def cs_verifyall(root_path=None, out_path=None, ext_logger=None, stream=None):
     EXT_LOGGER = ext_logger
     set_paths(root_path, out_path)
     suite = unittest.TestLoader().loadTestsFromTestCase(cs_verify)
-    if stream == None:
+    if stream is None:
         stream = sys.stderr
     testResult = unittest.TextTestRunner(verbosity=0, stream=stream).run(suite)
     EXT_LOGGER = None


### PR DESCRIPTION
Originally reported here: https://groups.google.com/forum/#!topic/circuitscape/1Jx7UDfaygM

Recent versions of numpy issue warning warning about an imminent change in behavior of `array == None` constructs. See http://lists.ipython.scipy.org/pipermail/numpy-discussion/2014-September/071235.html.

This commit changes all instances of `== None` and variants to equivalent `is None` type of constructs.