### PR TITLE
Fix bug in creating temp polymap

### DIFF
--- a/circuitscape/compute.py
+++ b/circuitscape/compute.py
@@ -335,7 +335,7 @@ class Compute(ComputeBase):
             poly_map_temp = point_map
         else:
             poly_map_temp = poly_map
-            new_poly_num = np.max(poly_map)
+            new_poly_num = np.max(poly_map) + 1
             #burn in src pt_idx to polygon map
             poly_map_temp = self.get_overlap_polymap(points_rc[pt1_idx,0], point_map, poly_map_temp, new_poly_num)                     
             for pt_idx in range(0, points_rc.shape[0]): #burn in dst points to polygon map


### PR DESCRIPTION
The reason this is a bug is because when you’re creating a new poly map from a point map and an old poly map, you shouldn’t start labelling from **`max(original map)`** but **`max(original map) + 1`**. This ensures that you don’t accidentally create a short circuit between an unrelated focal point from the point map and an existing short circuit region. 