### PR TITLE
Change from 1d to 2d array when necessary

### DIFF
--- a/circuitscape/csio.py
+++ b/circuitscape/csio.py
@@ -116,17 +116,17 @@ class CSIO:
             else:
                 pmap = np.loadtxt(filename, skiprows=6, dtype=data_type)
                 pmap = np.where(pmap==nodata, -9999, pmap)
-        
-        if nrows == 1:
+
+        if nrows == 1 and pmap.ndim == 1:
             temp = np.zeros((1,pmap.size))
             temp[0,:] = pmap
             pmap = temp
-            
-        if ncols == 1:
+
+        if ncols == 1 and pmap.ndim == 1:
             temp = np.zeros((pmap.size,1))
             temp[:,0] = pmap
-            pmap = temp       
-      
+            pmap = temp
+
         return pmap
 
 


### PR DESCRIPTION
Change Numpy array from a 1-dimensional array to a 2-dimensional array only when array is actually 1d.  Resolves ValueError: could not broadcast input array from shape (x,1) into shape (x).