### PR TITLE
Check if focal node file is empty

### DIFF
--- a/circuitscape/csio.py
+++ b/circuitscape/csio.py
@@ -354,6 +354,9 @@ class CSIO:
             points_rc = np.c_[values, rows, cols]
         else:
             raise RuntimeError('Focal node file must be in one of text list, ascii grid or numpy array format.')
+
+        if points_rc.size == 0:
+            raise RuntimeError('Focal node file does not contain any data.')
     
         try:
             i = np.argsort(points_rc[:,0])


### PR DESCRIPTION
Eliminates "ValueError: zero-size array to reduction operation minimum which has no identity", which is reported when Circuitscape begins to make sure points fall within cellmap.